### PR TITLE
Fix bug tapjoy callback is not calling on iOS

### DIFF
--- a/flutter_tapjoy-2.0.0/ios/Classes/FlutterTapjoyPlugin.m
+++ b/flutter_tapjoy-2.0.0/ios/Classes/FlutterTapjoyPlugin.m
@@ -7,12 +7,12 @@ FlutterViewController* flutterViewController;
     NSDictionary *placements;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  FlutterMethodChannel* channel = [FlutterMethodChannel
+  tapJoyChannel = [FlutterMethodChannel
       methodChannelWithName:@"flutter_tapjoy"
             binaryMessenger:[registrar messenger]];
     FlutterTapjoyPlugin* instance = [[FlutterTapjoyPlugin alloc] init];
     
-  [registrar addMethodCallDelegate:instance channel:channel];
+  [registrar addMethodCallDelegate:instance channel:tapJoyChannel];
     
   flutterViewController =
     [[FlutterViewController alloc] initWithProject:nil


### PR DESCRIPTION
There was problem that callback is not calling on iOS,
because using different `FlutterMethodChannel` which didn't registered